### PR TITLE
Fix nonce getting modified leading to "invalid header" error

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,6 +97,7 @@ exports.createDecryptStream = function (key, nonce) {
   }
   else if(!(key.length === 32 && nonce.length === 24))
     throw new Error('nonce must be 24 bytes')
+  nonce = copy(nonce)
 
   var reader = Reader(), first = true,  ended
   var first = true


### PR DESCRIPTION
Test case below. Comment out one of the items of the `blobs` array, and the script succeeds. When both are in the array, the script fails.

I would guess this may be an undeclared variable somewhere that is carrying some state between the calls to createUnboxStream

```
var pull = require('pull-stream')
var BoxStream = require('pull-box-stream')
var multicb = require('multicb')
var fs = require('fs')

var zeros = new Buffer(24); zeros.fill(0)

var blob1 = {
  name: '1',
  read: pull.once(new Buffer('BXLq7lJOFUXrrMnDROjnrzTwfM01QI98wVADK7NB4n7pBoAhtokrbFH223En7b2tkB/tRqTWJ/ULzrapIOoR8UD2CCnl4A==', 'base64')),
  key: new Buffer('Q1WkaxnTSNwvV8BG+O9j1FOOu5NgAPPJ7pVKJ0YN2GU=', 'base64')
}

var blob2 = {
  name: '2',
  read: pull.once(new Buffer('PH36RTKZDbIQX2d4ECl3vBTiKVfqbzQCGpvk1z8/8iOwygJiX4qL5znZRUHGz34UCp65mExmqcRVlR76DkMBGUG/sw/9FA==', 'base64')),
  key: new Buffer('U8I05ehHK2rFHBrhyrP+BvrQU7646/2Jd7AQZVv908M=', 'base64')
}

var blobs = [
  blob1,
  blob2,
]

function getBlob(blob, cb) {
  console.log('get', blob.name)
  pull(
    blob.read,
    BoxStream.createUnboxStream(blob.key, zeros),
    pull.drain(null, function (err) {
      console.log('end', blob.name)
      cb(err)
    })
  )
}

pull(
  pull.values(blobs),
  pull.asyncMap(getBlob),
  pull.drain()
)
```

error:

```
get 1
end 1
get 2
end 2
/home/cel/node_modules/pull-stream/sinks/drain.js:22
                throw end
                ^

Error: invalid header
    at Object.cb (/home/cel/node_modules/pull-box-stream/index.js:122:24)
    at drain (/home/cel/node_modules/pull-reader/index.js:39:14)
    at more (/home/cel/node_modules/pull-reader/index.js:51:13)
    at Function.reader.read (/home/cel/node_modules/pull-reader/index.js:95:7)
    at /home/cel/node_modules/pull-box-stream/index.js:115:14
    at next (/home/cel/node_modules/pull-stream/sinks/drain.js:16:11)
    at sink (/home/cel/node_modules/pull-stream/sinks/drain.js:37:9)
    at pull (/home/cel/node_modules/pull-stream/pull.js:41:14)
    at getBlob (/home/cel/src/pull-box-stream/box-dec-test.js:27:3)
    at /home/cel/node_modules/pull-stream/throughs/async-map.js:28:13
```