### PR TITLE
Fix non-strict syntax by removing global return

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -105,7 +105,10 @@ tape('encrypt/decrypt simple', function (t) {
     })
   )
 })
-return
+
+
+// HACK: disables all future tests instead of using global `return
+tape = function () {}
 
 tape('encrypt/decrypt', function (t) {
 


### PR DESCRIPTION
This resolves an issue where the module wasn't able to be parsed in strict mode.

See: ssbc/ssb-server#683